### PR TITLE
Add French translation

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -27,7 +27,7 @@ android {
         versionName = "1.1.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-        resourceConfigurations.addAll(listOf("en", "hr"))
+        resourceConfigurations.addAll(listOf("en", "fr", "hr"))
     }
 
     buildTypes {

--- a/app/src/main/java/com/davidtakac/bura/common/Capitalize.kt
+++ b/app/src/main/java/com/davidtakac/bura/common/Capitalize.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2024 David Takač
+ *
+ * This file is part of Bura.
+ *
+ * Bura is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * Bura is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Bura. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.davidtakac.bura.common
+
+import java.util.Locale
+
+fun String.capitalize(locale: Locale): String =
+    replaceFirstChar { if (it.isLowerCase()) it.titlecase(locale) else it.toString() }

--- a/app/src/main/java/com/davidtakac/bura/common/HighLowText.kt
+++ b/app/src/main/java/com/davidtakac/bura/common/HighLowText.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2024 David Takač
+ *
+ * This file is part of Bura.
+ *
+ * Bura is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * Bura is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Bura. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.davidtakac.bura.common
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.text.InlineTextContent
+import androidx.compose.foundation.text.appendInlineContent
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.Placeholder
+import androidx.compose.ui.text.PlaceholderVerticalAlign
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.withStyle
+import com.davidtakac.bura.R
+
+@Composable
+fun HighLowText(
+    high: String,
+    low: String,
+    modifier: Modifier = Modifier,
+    style: TextStyle = LocalTextStyle.current,
+    color: Color = LocalContentColor.current
+) {
+    val inlineContentMap = mapOf(
+        "high" to InlineTextContent(
+            placeholder = Placeholder(
+                width = style.fontSize,
+                height = style.fontSize,
+                placeholderVerticalAlign = PlaceholderVerticalAlign.TextCenter
+            )
+        ) {
+            Icon(
+                painter = painterResource(id = R.drawable.arrow_up),
+                contentDescription = null,
+                modifier = Modifier.fillMaxSize(),
+                tint = color
+            )
+        },
+        "low" to InlineTextContent(
+            placeholder = Placeholder(
+                width = style.fontSize,
+                height = style.fontSize,
+                placeholderVerticalAlign = PlaceholderVerticalAlign.TextCenter
+            )
+        ) {
+            Icon(
+                painter = painterResource(id = R.drawable.arrow_up),
+                contentDescription = null,
+                modifier = Modifier.fillMaxSize().rotate(180f),
+                tint = color
+            )
+        },
+    )
+    val annotatedString = buildAnnotatedString {
+        withStyle(style.toSpanStyle()) {
+            appendInlineContent(id = "high")
+            append(high)
+            append(" ")
+            appendInlineContent(id = "low")
+            append(low)
+        }
+    }
+    Text(
+        text = annotatedString,
+        inlineContent = inlineContentMap,
+        color = color,
+        modifier = modifier
+    )
+}

--- a/app/src/main/java/com/davidtakac/bura/common/Locale.kt
+++ b/app/src/main/java/com/davidtakac/bura/common/Locale.kt
@@ -25,8 +25,8 @@ import java.util.Locale
 private val fallbackLocale = Locale.US
 private val supportedLocales = listOf(
     fallbackLocale,
+    Locale.forLanguageTag("fr"),
     Locale.forLanguageTag("hr"),
-    Locale.forLanguageTag("fr")
 )
 
 private fun appLocale(context: Context): Locale {

--- a/app/src/main/java/com/davidtakac/bura/common/Locale.kt
+++ b/app/src/main/java/com/davidtakac/bura/common/Locale.kt
@@ -23,7 +23,11 @@ import java.time.format.DateTimeFormatter
 import java.util.Locale
 
 private val fallbackLocale = Locale.US
-private val supportedLocales = listOf(fallbackLocale, Locale.forLanguageTag("hr"))
+private val supportedLocales = listOf(
+    fallbackLocale,
+    Locale.forLanguageTag("hr"),
+    Locale.forLanguageTag("fr")
+)
 
 private fun appLocale(context: Context): Locale {
     val defaultLocale = context.resources.configuration.locales[0]

--- a/app/src/main/java/com/davidtakac/bura/graphs/common/GraphsPagerIndicator.kt
+++ b/app/src/main/java/com/davidtakac/bura/graphs/common/GraphsPagerIndicator.kt
@@ -36,6 +36,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.davidtakac.bura.R
 import com.davidtakac.bura.common.AppTheme
+import com.davidtakac.bura.common.capitalize
+import com.davidtakac.bura.common.rememberAppLocale
 import com.davidtakac.bura.common.rememberDateTimeFormatter
 import java.time.LocalDate
 
@@ -53,7 +55,7 @@ fun GraphsPagerIndicator(
                 selected = idx == selected,
                 onClick = { onClick(date) },
                 unselectedContentColor = MaterialTheme.colorScheme.onSurfaceVariant,
-                text = { Text(formatter.format(date)) },
+                text = { Text(formatter.format(date).capitalize(rememberAppLocale())) },
                 icon = { Text(text = "${date.dayOfMonth}") }
             )
         }

--- a/app/src/main/java/com/davidtakac/bura/graphs/temperature/TemperatureGraphSummary.kt
+++ b/app/src/main/java/com/davidtakac/bura/graphs/temperature/TemperatureGraphSummary.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.davidtakac.bura.R
 import com.davidtakac.bura.common.AppTheme
+import com.davidtakac.bura.common.HighLowText
 import com.davidtakac.bura.condition.Condition
 import com.davidtakac.bura.condition.image
 import com.davidtakac.bura.condition.string
@@ -69,12 +70,9 @@ fun TemperatureGraphSummary(state: TemperatureGraphSummary, modifier: Modifier =
                     else -> Text(stringResource(R.string.cond_screen_temp_unit_fahrenheit))
                 }
 
-                else -> Text(
-                    text = stringResource(
-                        id = R.string.temp_value_high_low,
-                        state.maxTemp.string(),
-                        state.minTemp.string()
-                    )
+                else -> HighLowText(
+                    high = state.maxTemp.string(),
+                    low = state.minTemp.string()
                 )
             }
         },

--- a/app/src/main/java/com/davidtakac/bura/place/picker/PlacePickerResults.kt
+++ b/app/src/main/java/com/davidtakac/bura/place/picker/PlacePickerResults.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.davidtakac.bura.R
 import com.davidtakac.bura.place.Place
@@ -145,7 +146,10 @@ private fun DeletePlaceDialog(name: String, onDismiss: () -> Unit, onConfirm: ()
             )
         },
         title = {
-            Text(text = stringResource(id = R.string.delete_place_value, name))
+            Text(
+                text = stringResource(id = R.string.delete_place_value, name),
+                textAlign = TextAlign.Center
+            )
         },
         text = {
             Text(text = stringResource(id = R.string.delete_place_description))

--- a/app/src/main/java/com/davidtakac/bura/place/picker/PlacePickerSearchBar.kt
+++ b/app/src/main/java/com/davidtakac/bura/place/picker/PlacePickerSearchBar.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.davidtakac.bura.R
@@ -117,7 +118,11 @@ fun PlacePickerSearchBar(
             )
         },
         placeholder = {
-            Text(text = stringResource(id = R.string.place_picker_hint_search))
+            Text(
+                text = stringResource(id = R.string.place_picker_hint_search),
+                overflow = TextOverflow.Ellipsis,
+                maxLines = 1
+            )
         },
         modifier = Modifier
             .fillMaxWidth()

--- a/app/src/main/java/com/davidtakac/bura/place/saved/SavedPlaceItem.kt
+++ b/app/src/main/java/com/davidtakac/bura/place/saved/SavedPlaceItem.kt
@@ -39,12 +39,12 @@ import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.davidtakac.bura.R
 import com.davidtakac.bura.common.AppTheme
+import com.davidtakac.bura.common.HighLowText
 import com.davidtakac.bura.common.rememberDateTimeFormatter
 import com.davidtakac.bura.condition.Condition
 import com.davidtakac.bura.condition.image
@@ -148,12 +148,9 @@ fun SavedPlaceItem(
                         contentDescription = null
                     )
                 }
-                Text(
-                    text = stringResource(
-                        id = R.string.temp_value_high_low,
-                        it.maxTemp.string(),
-                        it.minTemp.string()
-                    ),
+                HighLowText(
+                    high = it.maxTemp.string(),
+                    low = it.minTemp.string(),
                     style = MaterialTheme.typography.bodyMedium
                 )
             }

--- a/app/src/main/java/com/davidtakac/bura/summary/daily/DaySummaryRow.kt
+++ b/app/src/main/java/com/davidtakac/bura/summary/daily/DaySummaryRow.kt
@@ -46,6 +46,8 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.davidtakac.bura.R
 import com.davidtakac.bura.common.AppTheme
+import com.davidtakac.bura.common.capitalize
+import com.davidtakac.bura.common.rememberAppLocale
 import com.davidtakac.bura.common.rememberDateTimeFormatter
 import com.davidtakac.bura.condition.Condition
 import com.davidtakac.bura.condition.image
@@ -115,7 +117,7 @@ fun DaySummaryRow(
                 DayAndPop(
                     day = {
                         Text(
-                            text = if (state.isToday) stringResource(R.string.date_time_today) else state.time.format(formatter),
+                            text = if (state.isToday) stringResource(R.string.date_time_today) else state.time.format(formatter).capitalize(rememberAppLocale()),
                             maxLines = 1,
                             overflow = TextOverflow.Ellipsis
                         )
@@ -126,7 +128,9 @@ fun DaySummaryRow(
                         }
                     }
                 )
-                Spacer(modifier = Modifier.weight(1f).widthIn(min = 4.dp))
+                Spacer(modifier = Modifier
+                    .weight(1f)
+                    .widthIn(min = 4.dp))
                 Image(
                     painter = state.desc.image(),
                     contentDescription = null,

--- a/app/src/main/java/com/davidtakac/bura/summary/now/NowSummary.kt
+++ b/app/src/main/java/com/davidtakac/bura/summary/now/NowSummary.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.davidtakac.bura.R
 import com.davidtakac.bura.common.AppTheme
+import com.davidtakac.bura.common.HighLowText
 import com.davidtakac.bura.common.TextSkeleton
 import com.davidtakac.bura.condition.Condition
 import com.davidtakac.bura.condition.image
@@ -62,12 +63,9 @@ fun NowSummary(state: NowSummary, modifier: Modifier = Modifier) {
             )
         },
         highLow = {
-            Text(
-                stringResource(
-                    id = R.string.temp_value_high_low,
-                    state.maxTemp.string(),
-                    state.minTemp.string()
-                )
+            HighLowText(
+                high = state.maxTemp.string(),
+                low = state.minTemp.string()
             )
         },
         feelsLike = {

--- a/app/src/main/java/com/davidtakac/bura/summary/sun/SunSummary.kt
+++ b/app/src/main/java/com/davidtakac/bura/summary/sun/SunSummary.kt
@@ -25,6 +25,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.davidtakac.bura.R
+import com.davidtakac.bura.common.capitalize
+import com.davidtakac.bura.common.rememberAppLocale
 import com.davidtakac.bura.summary.SummaryTile
 import com.davidtakac.bura.common.rememberDateTimeFormatter
 import java.time.Duration
@@ -33,6 +35,7 @@ import java.time.LocalTime
 
 @Composable
 fun SunSummary(state: SunSummary, modifier: Modifier = Modifier) {
+    val locale = rememberAppLocale()
     val dayFormatter = rememberDateTimeFormatter(ofPattern = R.string.date_time_pattern_dow)
     val timeFormatter = rememberDateTimeFormatter(ofPattern = R.string.date_time_pattern_hour_minute)
     val dayAndTimeFormatter = rememberDateTimeFormatter(ofPattern = R.string.date_time_pattern_dow_hour_minute)
@@ -45,8 +48,8 @@ fun SunSummary(state: SunSummary, modifier: Modifier = Modifier) {
                     is Sunrise.WithSunsetSoon -> timeFormatter.format(state.time)
                     is Sunset.WithSunriseSoon -> timeFormatter.format(state.time)
 
-                    is Sunrise.Later -> dayFormatter.format(state.time)
-                    is Sunset.Later -> dayFormatter.format(state.time)
+                    is Sunrise.Later -> dayFormatter.format(state.time).capitalize(locale)
+                    is Sunset.Later -> dayFormatter.format(state.time).capitalize(locale)
 
                     is Sunrise.WithSunsetLater -> timeFormatter.format(state.time)
                     is Sunset.WithSunriseLater -> timeFormatter.format(state.time)

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1,0 +1,223 @@
+<!--
+  ~ Copyright 2024 David Takač
+  ~
+  ~ This file is part of Bura.
+  ~
+  ~ Bura is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+  ~
+  ~ Bura is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License along with Bura. If not, see <https://www.gnu.org/licenses/>.
+  -->
+
+<resources>
+    <string name="app_name">Bura</string>
+    <string name="general_error_failed_to_download">Échec de téléchargement des prévisions. Connectez-vous à Internet et réessayez.</string>
+    <string name="general_error_outdated">Vos données de prévisions sont obsolètes. Connectez-vous à Internet et réessayez.</string>
+    <string name="general_error_no_selected_place">Aucun emplacement sélectionné.</string>
+    <string name="general_btn_try_again">Réessayer</string>
+    <string name="general_btn_select_place">Sélectionner un emplacement</string>
+    <string name="general_btn_dialog_confirm">OK</string>
+    <string name="general_btn_dialog_cancel">Annuler</string>
+
+    <string name="credit_weather">Données météo par Open-Meteo.com</string>
+    <string name="credit_geocoding">Données de géocodage par Open-Meteo.com</string>
+
+    <string name="place_picker_hint_search">Rechercher des emplacements…</string>
+    <string name="place_picker_title_saved_places">Emplacements enregistrés</string>
+    <string name="place_picker_title_search_results">Résultats de recherche</string>
+    <string name="place_picker_error_no_internet">Vous semblez hors ligne. Connectez-vous à Internet et réessayez.</string>
+    <string name="place_picker_error_value_no_results_for">Pas de résultats pour “%s”.</string>
+    <string name="place_picker_error_no_saved_places">Aucun emplacement enregistré.</string>
+    <string name="delete_place_value">Supprimer “%s” ?</string>
+    <string name="delete_place_description">Cela supprimera également les données de prévision mises en cache.</string>
+
+    <string name="cond_screen_title">Conditions</string>
+    <string name="cond_screen_pop">Probabilité de précipitations</string>
+    <string name="cond_screen_precip">Quantité de précipitations</string>
+    <string name="cond_screen_temp_unit_celsius">Celsius (°C)</string>
+    <string name="cond_screen_temp_unit_fahrenheit">Fahrenheit (°F)</string>
+    <string name="cond_screen_precip_value_in_last_hours">%s dernières heures</string>
+    <string name="cond_screen_precip_value_in_next_hours">%s prochaines heures</string>
+
+    <string name="settings_screen_title">Paramètres</string>
+    <string name="settings_screen_title_units">Unités</string>
+    <string name="settings_screen_title_temp_unit">Température</string>
+    <string name="settings_screen_label_temp_unit_celsius">Degrés Celsius</string>
+    <string name="settings_screen_label_temp_unit_fahrenheit">Degrés Fahrenheit</string>
+    <string name="settings_screen_title_wind_unit">Vent</string>
+    <string name="settings_screen_label_wind_unit_mps">Mètres par seconde</string>
+    <string name="settings_screen_label_wind_unit_kph">Kilomètres par heure</string>
+    <string name="settings_screen_label_wind_unit_mph">Miles par heure</string>
+    <string name="settings_screen_label_wind_unit_kn">Nœuds</string>
+    <string name="settings_screen_title_precip_unit">Précipitations</string>
+    <string name="settings_screen_title_rain_unit">Pluie</string>
+    <string name="settings_screen_title_showers_unit">Averses</string>
+    <string name="settings_screen_title_snow_unit">Neige</string>
+    <string name="settings_screen_label_precip_unit_mm">Millimètres</string>
+    <string name="settings_screen_label_precip_unit_cm">Centimètres</string>
+    <string name="settings_screen_label_precip_unit_in">Pouces</string>
+    <string name="settings_screen_title_pressure_unit">Pression</string>
+    <string name="settings_screen_label_pressure_unit_hpa">Hectopascal</string>
+    <string name="settings_screen_label_pressure_unit_inhg">Pouces de mercure</string>
+    <string name="settings_screen_label_pressure_unit_mmhg">Millimètres de mercure</string>
+    <string name="settings_screen_title_vis_unit">Visibilité</string>
+    <string name="settings_screen_label_vis_unit_km">Kilomètres</string>
+    <string name="settings_screen_label_vis_unit_mi">Miles</string>
+    <string name="settings_screen_label_vis_unit_m">Mètres</string>
+    <string name="settings_screen_label_vis_unit_ft">Pied</string>
+    <string name="settings_screen_title_appearance">Apparence</string>
+    <string name="settings_screen_title_theme">Thème</string>
+    <string name="settings_screen_label_dark">Sombre</string>
+    <string name="settings_screen_label_light">Clair</string>
+    <string name="settings_screen_label_follow_system">Préférence système</string>
+
+    <string name="date_time_now">Actuel</string>
+    <string name="date_time_today">Auj.</string>
+    <string name="date_time_pattern_hour">HH</string>
+    <string name="date_time_pattern_hour_minute">HH:mm</string>
+    <string name="date_time_pattern_dow">E</string>
+    <string name="date_time_pattern_dow_hour_minute">E, HH:mm</string>
+    <string name="date_time_pattern_dow_dom_month">E d MMM</string>
+
+    <string name="precip_mixed">Précipitations</string>
+    <string name="precip_rain">Pluie</string>
+    <string name="precip_showers">Averses</string>
+    <string name="precip_snow">Neige</string>
+    <string name="precip_value_in_last_hours">Dans les dernières %s h</string>
+    <string name="precip_value_showers_in_next_hours">%1$s d’averses prévus dans les prochaines %2$s h.</string>
+    <string name="precip_value_rain_in_next_hours">%1$s de pluie prévus dans les prochaines %2$s h.</string>
+    <string name="precip_value_snow_in_next_hours">%1$s de neige prévus dans les prochaines %2$s h.</string>
+    <string name="precip_value_mixed_in_next_hours">%1$s prévus dans les prochaines %2$s h.</string>
+    <string name="precip_value_showers_on_day">%1$s d’averses prévus à %2$s.</string>
+    <string name="precip_value_rain_on_day">%1$s de pluie prévus à %2$s.</string>
+    <string name="precip_value_snow_on_day">%1$s de neige prévus à %2$s.</string>
+    <string name="precip_value_mixed_on_day">%1$s à %2$s.</string>
+    <string name="precip_value_none_in_next_days">Aucune prévue dans les prochains %s j.</string>
+    <string name="precip_unit_mm">mm</string>
+    <string name="precip_value_mm">%s mm</string>
+    <string name="precip_unit_cm">cm</string>
+    <string name="precip_value_cm">%s cm</string>
+    <string name="precip_unit_in">″</string>
+    <string name="precip_value_in">%s″</string>
+
+    <string name="pop_value_percent">%s%%</string>
+
+    <string name="pressure">Pression</string>
+    <string name="pressure_trend_falling">En chute</string>
+    <string name="pressure_trend_steady">Stable</string>
+    <string name="pressure_trend_rising">En augmentation</string>
+    <string name="pressure_value_average">Moyenne : %s</string>
+    <string name="pressure_unit_hpa">hPa</string>
+    <string name="pressure_value_hpa">%s hPa</string>
+    <string name="pressure_unit_inhg">inHg</string>
+    <string name="pressure_value_inhg">%s inHg</string>
+    <string name="pressure_unit_mmhg">mmHg</string>
+    <string name="pressure_value_mmhg">%s mmHg</string>
+
+    <string name="humidity">Humidité</string>
+    <string name="humidity_value_percent">%s %%</string>
+
+    <string name="sunrise">Lever du soleil</string>
+    <string name="sunset">Coucher du soleil</string>
+    <string name="sunrise_value">Lever du soleil : %s</string>
+    <string name="sunset_value">Coucher du soleil : %s</string>
+    <string name="sunrise_not_today">Pas de lever du soleil aujourd’hui.</string>
+    <string name="sunset_not_today">Pas de coucher du soleil aujourd’hui.</string>
+    <string name="sunrise_value_more_than_days_away">&gt; %s j</string>
+    <string name="sunrise_value_more_than_hours_away">&gt; %s h</string>
+    <string name="sunset_value_more_than_days_away">&gt; %s j</string>
+    <string name="sunset_value_more_than_hours_away">&gt; %s h</string>
+
+    <string name="temp_value_degree">%s°</string>
+    <string name="temp_value_high_low">↑%s ↓%s</string>
+    <string name="dew_point_value_right_now">Le point de rosée est actuellement de %s.</string>
+    <string name="feels_like">Ressenti</string>
+    <string name="feels_like_value">Ressenti %s</string>
+    <string name="feels_like_value_actual">Mesurée %s</string>
+    <string name="feels_like_cooler_than_actual">Le vent donne une impression de fraîcheur.</string>
+    <string name="feels_like_colder_than_actual">Le vent donne une impression de froid.</string>
+    <string name="feels_like_warmer_than_actual">L’humidité donne une impression de fraîcheur.</string>
+    <string name="feels_like_hotter_than_actual">L’humidité donne une impression de chaleur.</string>
+    <string name="feels_like_similar_to_actual">Similaire à la température mesurée.</string>
+
+    <string name="uv_index">Indice UV</string>
+    <string name="uv_index_risk_low">Faible</string>
+    <string name="uv_index_risk_moderate">Modéré</string>
+    <string name="uv_index_risk_high">Élevé</string>
+    <string name="uv_index_risk_very_high">Très élevé</string>
+    <string name="uv_index_risk_extreme">Extrême</string>
+    <string name="uv_index_protection_value_from_until">Utiliser une protection solaire entre %1$s et %2$s.</string>
+    <string name="uv_index_protection_value_from">Utiliser une protection solaire à partir de %s.</string>
+    <string name="uv_index_protection_value_until">Utiliser une protection solaire jusqu’à %s.</string>
+    <string name="uv_index_protection_value_until_end_of_day">Utiliser une protection solaire jusqu’à la fin de journée.</string>
+    <string name="uv_index_protection_value_none">Faible jusqu’à la fin de journée.</string>
+
+    <string name="vis">Visibilité</string>
+    <string name="vis_unit_m">m</string>
+    <string name="vis_value_m">%s m</string>
+    <string name="vis_unit_ft">ft</string>
+    <string name="vis_value_ft">%s ft</string>
+    <string name="vis_unit_km">km</string>
+    <string name="vis_value_km">%s km</string>
+    <string name="vis_unit_mi">mi</string>
+    <string name="vis_value_mi">%s mi</string>
+    <string name="vis_description_perfect">Vue complètement dégagée.</string>
+    <string name="vis_description_clear">Vue dégagée.</string>
+    <string name="vis_description_fair">Vue plutôt dégagée.</string>
+    <string name="vis_description_low">Vue réduite.</string>
+    <string name="vis_description_very_low">Vue très réduite.</string>
+
+    <string name="wind_label">Vent</string>
+    <string name="wind_bft_0">Calme</string>
+    <string name="wind_bft_1">Très légère brise</string>
+    <string name="wind_bft_2">Légère brise</string>
+    <string name="wind_bft_3">Petite brise</string>
+    <string name="wind_bft_4">Jolie brise</string>
+    <string name="wind_bft_5">Bonne brise</string>
+    <string name="wind_bft_6">Vent frais</string>
+    <string name="wind_bft_7">Grand frais</string>
+    <string name="wind_bft_8">Coup de vent</string>
+    <string name="wind_bft_9">Fort coup de vent</string>
+    <string name="wind_bft_10">Tempête</string>
+    <string name="wind_bft_11">Violente tempête</string>
+    <string name="wind_bft_12">Ouragan</string>
+    <string name="wind_value_gusts_at">Rafales à %s.</string>
+    <string name="wind_unit_mps">m/s</string>
+    <string name="wind_value_mps">%s m/s</string>
+    <string name="wind_unit_kph">km/h</string>
+    <string name="wind_value_kph">%s km/h</string>
+    <string name="wind_unit_kn">kn</string>
+    <string name="wind_value_kn">%s kn</string>
+    <string name="wind_unit_mph">mi/h</string>
+    <string name="wind_value_mph">%s mi/h</string>
+
+    <string name="wmo_0">Dégagé</string>
+    <string name="wmo_1">Principalement dégagé</string>
+    <string name="wmo_2">Partiellement couvert</string>
+    <string name="wmo_3">Couvert</string>
+    <string name="wmo_45">Brouillard</string>
+    <string name="wmo_48">Dépôt d’un brouillard de givre</string>
+    <string name="wmo_51">Bruine légère</string>
+    <string name="wmo_53">Bruine</string>
+    <string name="wmo_55">Bruine dense</string>
+    <string name="wmo_56">Bruine verglaçante légère</string>
+    <string name="wmo_57">Bruine verglaçante dense</string>
+    <string name="wmo_61">Pluie faible</string>
+    <string name="wmo_63">Pluie</string>
+    <string name="wmo_65">Pluie forte</string>
+    <string name="wmo_66">Pluie verglaçante légère</string>
+    <string name="wmo_67">Pluie verglaçante forte</string>
+    <string name="wmo_71">Neige légère</string>
+    <string name="wmo_73">Neige</string>
+    <string name="wmo_75">Neige forte</string>
+    <string name="wmo_77">Neige en grains</string>
+    <string name="wmo_80">Averses légères</string>
+    <string name="wmo_81">Averses</string>
+    <string name="wmo_82">Averses fortes</string>
+    <string name="wmo_85">Averses de neige légères</string>
+    <string name="wmo_86">Averses de neige fortes</string>
+    <string name="wmo_95">Orage</string>
+    <string name="wmo_96">Orage avec légère grêle</string>
+    <string name="wmo_99">Orage avec forte grêle</string>
+</resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -78,7 +78,6 @@
     <string name="date_time_pattern_hour_minute">HH:mm</string>
     <string name="date_time_pattern_dow">E</string>
     <string name="date_time_pattern_dow_hour_minute">E, HH:mm</string>
-    <string name="date_time_pattern_dow_dom_month">E d MMM</string>
 
     <string name="precip_mixed">Précipitations</string>
     <string name="precip_rain">Pluie</string>
@@ -130,7 +129,6 @@
     <string name="sunset_value_more_than_hours_away">&gt; %s h</string>
 
     <string name="temp_value_degree">%s°</string>
-    <string name="temp_value_high_low">↑%s ↓%s</string>
     <string name="dew_point_value_right_now">Le point de rosée est actuellement de %s.</string>
     <string name="feels_like">Ressenti</string>
     <string name="feels_like_value">Ressenti %s</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -29,6 +29,7 @@
     <string name="delete_place_description">Ovo će obrisati i spremljenu prognozu mjesta.</string>
     <string name="cond_screen_title">Uvjeti</string>
     <string name="cond_screen_pop">Vjerojatnost padalina</string>
+    <string name="cond_screen_precip">Količina padalina</string>
     <string name="cond_screen_temp_unit_celsius">Celzij (°C)</string>
     <string name="cond_screen_temp_unit_fahrenheit">Fahrenheit (°F)</string>
     <string name="cond_screen_precip_value_in_last_hours">Posljednja %s sata</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -65,7 +65,7 @@
     <string name="settings_screen_label_light">Svijetla</string>
     <string name="settings_screen_label_follow_system">Prati sustav</string>
     <string name="date_time_now">Sada</string>
-    <string name="date_time_today">danas</string>
+    <string name="date_time_today">Danas</string>
     <string name="date_time_pattern_hour">HH</string>
     <string name="date_time_pattern_hour_minute">HH:mm</string>
     <string name="date_time_pattern_dow">E</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -70,7 +70,6 @@
     <string name="date_time_pattern_hour_minute">HH:mm</string>
     <string name="date_time_pattern_dow">E</string>
     <string name="date_time_pattern_dow_hour_minute">E, HH:mm</string>
-    <string name="date_time_pattern_dow_dom_month">E, d. MMM</string>
     <string name="precip_mixed">Padaline</string>
     <string name="precip_rain">Kiša</string>
     <string name="precip_showers">Pljuskovi</string>
@@ -116,7 +115,6 @@
     <string name="sunset_value_more_than_days_away">&gt; %sd</string>
     <string name="sunset_value_more_than_hours_away">&gt; %sd</string>
     <string name="temp_value_degree">%s°</string>
-    <string name="temp_value_high_low">V:%s N:%s</string>
     <string name="dew_point_value_right_now">Rosište je %s sada.</string>
     <string name="feels_like">Osjet</string>
     <string name="feels_like_value">Osjet %s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -127,7 +127,7 @@
     <string name="sunrise_value_more_than_days_away">&gt; %sd</string>
     <string name="sunrise_value_more_than_hours_away">&gt; %sh</string>
     <string name="sunset_value_more_than_days_away">&gt; %sd</string>
-    <string name="sunset_value_more_than_hours_away">&gt; %sd</string>
+    <string name="sunset_value_more_than_hours_away">&gt; %sh</string>
 
     <string name="temp_value_degree">%s°</string>
     <string name="temp_value_high_low">H:%s L:%s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -78,7 +78,6 @@
     <string name="date_time_pattern_hour_minute">HH:mm</string>
     <string name="date_time_pattern_dow">E</string>
     <string name="date_time_pattern_dow_hour_minute">E, HH:mm</string>
-    <string name="date_time_pattern_dow_dom_month">E, MMM d</string>
 
     <string name="precip_mixed">Precipitation</string>
     <string name="precip_rain">Rain</string>
@@ -130,7 +129,6 @@
     <string name="sunset_value_more_than_hours_away">&gt; %sh</string>
 
     <string name="temp_value_degree">%s°</string>
-    <string name="temp_value_high_low">H:%s L:%s</string>
     <string name="dew_point_value_right_now">The dew point is %s right now.</string>
     <string name="feels_like">Feels like</string>
     <string name="feels_like_value">Feels like %s</string>

--- a/app/src/main/res/xml/locales_config.xml
+++ b/app/src/main/res/xml/locales_config.xml
@@ -13,5 +13,6 @@
 
 <locale-config xmlns:android="http://schemas.android.com/apk/res/android">
     <locale android:name="en"/>
+    <locale android:name="fr"/>
     <locale android:name="hr"/>
 </locale-config>


### PR DESCRIPTION
French translation completed, tested with a debug build.
(I also fixed a copy/paste error in English translation)

A few issues encountered on app side:
- Search bar placeholder is cut, instead of being ellipsed (the last word of "Rechercher des emplacements" is cut at "des" instead of "emplacements" being ellipsed). We could make it slightly shorter by writing "Search for place" singular instead of "Search for places" plural)
- Open-Meteo search results are in English (shows "Germany" instead of "Allemagne")
- Days of the week are in English in the daily card on main screen
- Numbers formatted with the English (US) locale instead of French (shows 1,003 hPa instead of 1 003 hPa, or 0.1 km instead of 0,1 km)

App was force closed/restarted before being tested

I also recommand you [generate your `locales_config.xml` dynamically](https://github.com/breezy-weather/breezy-weather/blob/v5.2.0/buildSrc/src/main/kotlin/LocalesConfigPlugin.kt) for easier maintenance.